### PR TITLE
fix(cass): Handle cass search response wrapper format

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -311,7 +311,7 @@ export const CassSearchHitSchema = z.object({
   title: z.string().optional(),
   snippet: z.string(),
   score: z.number().optional(),
-  created_at: z.union([z.string(), z.number()]).optional(),
+  created_at: z.union([z.string(), z.number(), z.null()]).optional(),
 }).transform(data => ({
   ...data,
   sessionPath: data.source_path,


### PR DESCRIPTION
## Summary

- Fix cm failing to parse cass search results due to schema mismatch
- cass binary returns `{hits: [...], count: N}` wrapper, but cm expected direct array
- Also allow `null` in `created_at` field (some sessions lack timestamps)

## Problem

Running `cm context "any task" --json` would fail with Zod validation errors:

```
[cass-memory] ERROR: Cass search failed: [
  {"code": "invalid_type", "expected": "string", "received": "undefined", "path": ["source_path"], "message": "Required"},
  {"code": "invalid_type", "expected": "number", "received": "undefined", "path": ["line_number"], "message": "Required"},
  ...
]
```

## Root Cause

`cassSearch()` in `src/cass.ts` was parsing the raw cass output and expecting either:
- A direct array of hits: `[{source_path, line_number, ...}, ...]`
- A single hit object: `{source_path, line_number, ...}`

But cass v0.1.35 returns a wrapper object:
```json
{
  "count": 1,
  "hits": [{...}],
  "query": "...",
  ...
}
```

So the code was trying to validate the wrapper object against `CassHitSchema`, hence all required fields showing as "undefined".

## Fix

1. **src/cass.ts**: Extract `hits` array from wrapper, with fallback for backwards compatibility
2. **src/types.ts**: Allow `null` in `created_at` union type

## Test plan

- [x] `cm context "any task" --json` now returns `historySnippets` correctly
- [x] `cm doctor` self-test passes for cass search
- [x] `bun test test/cass*.test.ts` passes (4/4)
- [x] `bun test test/types.test.ts` passes (68/68)

🤖 Generated with [Claude Code](https://claude.com/claude-code)