### PR TITLE
feat: add configurable baseURL support for llm providers

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -41,6 +41,7 @@ export interface LLMConfig {
   model: string;
   apiKey?: string;
   ollamaBaseUrl?: string;
+  baseURL?: string;
 }
 
 /**
@@ -144,7 +145,7 @@ export function resolveOllamaBaseUrl(ollamaBaseUrl?: string): string {
   return ollamaBaseUrl || "http://localhost:11434";
 }
 
-export function getModel(config: { provider: string; model: string; apiKey?: string; ollamaBaseUrl?: string }): LanguageModel {
+export function getModel(config: { provider: string; model: string; apiKey?: string; ollamaBaseUrl?: string; baseURL?: string }): LanguageModel {
   const provider = config.provider as LLMProvider;
 
   if (provider === "ollama") {
@@ -156,10 +157,11 @@ export function getModel(config: { provider: string; model: string; apiKey?: str
   }
 
   const apiKey = config.apiKey || getApiKey(provider);
+  const baseURL = config.baseURL || process.env[`${provider.toUpperCase()}_BASE_URL` as keyof typeof process.env];
 
   switch (provider) {
-    case "openai": return createOpenAI({ apiKey })(config.model);
-    case "anthropic": return createAnthropic({ apiKey })(config.model);
+    case "openai": return createOpenAI({ apiKey, baseURL })(config.model);
+    case "anthropic": return createAnthropic({ apiKey, baseURL })(config.model);
     case "google": return createGoogleGenerativeAI({ apiKey })(config.model);
     default: throw new Error(`Unsupported provider: ${config.provider}`);
   }
@@ -477,7 +479,8 @@ export async function generateObjectSafe<T>(
       provider: config.provider as LLMProvider,
       model: config.model,
       apiKey: config.apiKey,
-      ollamaBaseUrl: config.ollamaBaseUrl
+      ollamaBaseUrl: config.ollamaBaseUrl,
+      baseURL: config.baseURL,
     };
     model = getModel(llmConfig);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -365,10 +365,12 @@ export const ConfigSchema = z.object({
   schema_version: z.number().default(1),
   llm: z.object({
     provider: z.string().default("anthropic"),
-    model: z.string().default("claude-sonnet-4-20250514")
+    model: z.string().default("claude-sonnet-4-20250514"),
+    baseURL: z.string().optional()
   }).optional(),
   provider: LLMProviderEnum.default("anthropic"),
   model: z.string().default("claude-sonnet-4-20250514"),
+  baseURL: z.string().optional(),
   cassPath: z.string().default("cass"),
   remoteCass: RemoteCassConfigSchema.default({}),
   playbookPath: z.string().default("~/.cass-memory/playbook.yaml"),


### PR DESCRIPTION
# PR Title

feat: add configurable baseURL support for OpenAI and Anthropic providers

# PR Body

## Summary

This PR adds optional `baseURL` support to the top-level config and passes it through to the OpenAI and Anthropic provider factories.

## Why

Some provider-compatible gateways require a custom API base URL instead of the default vendor endpoint. `cass_memory_system` already exposes provider/model configuration, so adding `baseURL` makes the LLM layer more flexible without changing the default behavior.

This also fixes a gap where config-level `baseURL` could be defined in the schema but was not fully propagated through the model construction path.

## Changes

- add optional `baseURL` to the config schema
- add optional `baseURL` to `LLMConfig`
- pass `baseURL` into `createOpenAI(...)` and `createAnthropic(...)`
- pass `config.baseURL` through `generateObjectSafe()` into `getModel()`

## Backward Compatibility

- no behavior changes when `baseURL` is not set
- existing configs continue to work unchanged

## Notes

I intentionally kept this PR focused on config + provider wiring only.
