### PR TITLE
feat(semantic): add Ollama embedding backend

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -31,7 +31,7 @@ import {
 import { withLock } from "../lock.js";
 import { getEffectiveScore } from "../scoring.js";
 import { ContextResult, ScoredBullet, Config, CassSearchHit, PlaybookBullet, ErrorCode } from "../types.js";
-import { cosineSimilarity, embedText, loadOrComputeEmbeddingsForBullets } from "../semantic.js";
+import { cosineSimilarity, embedText, loadOrComputeEmbeddingsForBullets, setEmbeddingBackend, configureOllamaEmbedding } from "../semantic.js";
 import chalk from "chalk";
 import { agentIconPrefix, formatRule, formatTipPrefix, getOutputStyle, iconPrefix, wrapText } from "../output.js";
 import { createProgress, type ProgressReporter } from "../progress.js";
@@ -235,6 +235,12 @@ export async function scoreBulletsEnhanced(
       ? config.embeddingModel.trim()
       : undefined;
   const semanticEnabled = config.semanticSearchEnabled && embeddingModel !== "none";
+
+  // Configure embedding backend from config
+  if ((config as any).embeddingBackend === "ollama") {
+    setEmbeddingBackend("ollama");
+    configureOllamaEmbedding((config as any).ollamaBaseUrl || "http://localhost:11434", embeddingModel);
+  }
 
   const semanticWeight = clamp01(
     typeof config.semanticWeight === "number" ? config.semanticWeight : 0.6

--- a/src/commands/similar.ts
+++ b/src/commands/similar.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { loadConfig } from "../config.js";
 import { loadMergedPlaybook, getActiveBullets } from "../playbook.js";
-import { findSimilarBulletsSemantic, getSemanticStatus, formatSemanticModeMessage } from "../semantic.js";
+import { findSimilarBulletsSemantic, getSemanticStatus, formatSemanticModeMessage, setEmbeddingBackend, configureOllamaEmbedding } from "../semantic.js";
 import { getEffectiveScore } from "../scoring.js";
 import { isJsonOutput, isToonOutput, jaccardSimilarity, truncate, getCliName, printStructuredResult, reportError, validateOneOf, warn } from "../utils.js";
 import { ErrorCode, PlaybookBullet } from "../types.js";
@@ -93,6 +93,12 @@ export async function generateSimilarResults(
       ? config.embeddingModel.trim()
       : undefined;
   const semanticEnabled = config.semanticSearchEnabled && embeddingModel !== "none";
+
+  // Configure embedding backend from config
+  if ((config as any).embeddingBackend === "ollama") {
+    setEmbeddingBackend("ollama");
+    configureOllamaEmbedding((config as any).ollamaBaseUrl || "http://localhost:11434", embeddingModel);
+  }
 
   if (semanticEnabled) {
     try {

--- a/src/semantic.ts
+++ b/src/semantic.ts
@@ -146,6 +146,58 @@ export async function getEmbedder(
   return embedderPromise;
 }
 
+// --- Ollama embedding backend ---
+
+let ollamaBaseUrl = "http://localhost:11434";
+let ollamaModel = "nomic-embed-text";
+
+export function configureOllamaEmbedding(baseUrl: string, model?: string): void {
+  ollamaBaseUrl = baseUrl.replace(/\/+$/, "");
+  if (model) ollamaModel = model;
+}
+
+async function embedTextOllama(text: string): Promise<number[]> {
+  const resp = await fetch(`${ollamaBaseUrl}/api/embed`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: ollamaModel, input: text }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Ollama embed failed (${resp.status}): ${await resp.text()}`);
+  }
+  const data: any = await resp.json();
+  const embeddings = data?.embeddings;
+  if (Array.isArray(embeddings) && embeddings.length > 0) {
+    return embeddings[0];
+  }
+  throw new Error("Ollama returned no embeddings");
+}
+
+async function batchEmbedOllama(texts: string[]): Promise<number[][]> {
+  const resp = await fetch(`${ollamaBaseUrl}/api/embed`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: ollamaModel, input: texts }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Ollama batch embed failed (${resp.status}): ${await resp.text()}`);
+  }
+  const data: any = await resp.json();
+  const embeddings = data?.embeddings;
+  if (Array.isArray(embeddings)) {
+    return embeddings;
+  }
+  throw new Error("Ollama returned no embeddings");
+}
+
+// --- Embedding backend selection ---
+
+let embeddingBackend: "xenova" | "ollama" = "xenova";
+
+export function setEmbeddingBackend(backend: "xenova" | "ollama"): void {
+  embeddingBackend = backend;
+}
+
 export async function embedText(
   text: string,
   options: { model?: string } = {}
@@ -154,6 +206,10 @@ export async function embedText(
   if (model === "none") return [];
   const cleaned = text?.trim();
   if (!cleaned) return [];
+
+  if (embeddingBackend === "ollama") {
+    return embedTextOllama(cleaned);
+  }
 
   const embedder = await getEmbedder(model);
   const result: any = await embedder(cleaned, { pooling: "mean", normalize: true });
@@ -173,6 +229,24 @@ export async function batchEmbed(
 ): Promise<number[][]> {
   const model = options.model || DEFAULT_EMBEDDING_MODEL;
   if (model === "none") return texts.map(() => []);
+
+  // Ollama backend: batch via API (handles its own batching)
+  if (embeddingBackend === "ollama") {
+    const cleaned = texts.map((t) => (typeof t === "string" ? t.trim() : ""));
+    const nonEmpty = cleaned.filter(t => t);
+    if (nonEmpty.length === 0) return cleaned.map(() => []);
+    const embeddings = await batchEmbedOllama(nonEmpty);
+    const output: number[][] = [];
+    let embIdx = 0;
+    for (const t of cleaned) {
+      if (t) { output.push(embeddings[embIdx++] || []); }
+      else { output.push([]); }
+    }
+    if (typeof options.onProgress === "function") {
+      options.onProgress({ processed: nonEmpty.length, total: nonEmpty.length });
+    }
+    return output;
+  }
 
   const safeBatchSize =
     Number.isFinite(batchSize) && batchSize > 0 ? Math.floor(batchSize) : 32;

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,6 +404,7 @@ export const ConfigSchema = z.object({
   semanticSearchEnabled: z.boolean().default(false),
   semanticWeight: z.number().min(0).max(1).default(0.6),
   embeddingModel: z.string().default("Xenova/all-MiniLM-L6-v2"),
+  embeddingBackend: z.enum(["xenova", "ollama"]).default("xenova"),
   verbose: z.boolean().default(false),
   jsonOutput: z.boolean().default(false),
   apiKey: z.string().optional(),


### PR DESCRIPTION
## Summary

Adds an alternative embedding backend that calls Ollama's `/api/embed` endpoint over HTTP, enabling GPU-accelerated semantic search on systems where the default `@xenova/transformers` ONNX runtime is unavailable.

**Motivation:** On WSL1, the ONNX native library crashes with `EINVAL` (mmap not supported on WSL1's 4.4.0 kernel). Bun-compiled Windows executables also fail because `sharp` native modules aren't bundled. This makes semantic search (`cm similar`, semantic dedup, context ranking) completely unusable on these platforms.

Ollama runs natively on Windows with full GPU support and serves embeddings via a simple HTTP API — no native library linking needed from the cm process.

## Changes

- `src/types.ts`: Add `embeddingBackend: "xenova" | "ollama"` config field (default: `"xenova"`, fully backward-compatible)
- `src/semantic.ts`: Add `embedTextOllama()`, `batchEmbedOllama()`, `setEmbeddingBackend()`, `configureOllamaEmbedding()` — uses Ollama's `/api/embed` endpoint with batch support
- `src/commands/similar.ts`: Wire up backend selection from config before semantic search
- `src/commands/context.ts`: Same wiring for context command

## Config

```json
{
  "semanticSearchEnabled": true,
  "embeddingBackend": "ollama",
  "embeddingModel": "nomic-embed-text",
  "ollamaBaseUrl": "http://localhost:11434"
}
```

When `embeddingBackend` is `"xenova"` (the default), behavior is completely unchanged.

## Tested on

- WSL1 (Windows 10, kernel 4.4.0) + Ollama 0.17.4 + RTX 5070 Ti
- `nomic-embed-text` model (768-dim embeddings)
- 348 playbook rules batch-embedded in ~2s
- `cm similar` returns semantically ranked results
- Semantic dedup found 93 duplicate pairs at 0.85 threshold