### PR TITLE
fix(llm): make disableStructuredOutputs actually work for openai-compatible gateways (DeepSeek/OpenRouter)

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -43,6 +43,7 @@ export interface LLMConfig {
   apiKey?: string;
   baseUrl?: string;
   ollamaBaseUrl?: string;
+  disableStructuredOutputs?: boolean;
 }
 
 /**
@@ -206,9 +207,15 @@ export function getModel(config: { provider: string; model: string; apiKey?: str
       const openaiProvider = createOpenAI({
         apiKey,
         ...(baseURL ? { baseURL } : {}),
-        ...(config.disableStructuredOutputs ? { structuredOutputs: false } : {}),
       });
-      return openaiProvider(config.model);
+      // NOTE: in @ai-sdk/openai 1.x `structuredOutputs` is a *model* setting;
+      // passing it to createOpenAI() is silently ignored (root cause of #47
+      // persisting). Apply it per-model so `disableStructuredOutputs: true`
+      // actually turns off strict json_schema / strict tool definitions.
+      return openaiProvider(
+        config.model,
+        config.disableStructuredOutputs ? { structuredOutputs: false } : {}
+      );
     }
     case "anthropic": return createAnthropic({ apiKey, ...(baseURL ? { baseURL } : {}) })(config.model);
     case "google": return createGoogleGenerativeAI({ apiKey, ...(baseURL ? { baseURL } : {}) })(config.model);
@@ -869,7 +876,10 @@ export async function generateObjectSafe<T>(
       model: config.model,
       apiKey: config.apiKey,
       baseUrl: config.baseUrl,
-      ollamaBaseUrl: config.ollamaBaseUrl
+      ollamaBaseUrl: config.ollamaBaseUrl,
+      // #47 escape hatch: without this line the flag was dropped here, so
+      // strict `json_schema` was still sent to gateways that reject it (400).
+      disableStructuredOutputs: config.disableStructuredOutputs
     };
     model = getModel(llmConfig);
   }
@@ -887,7 +897,14 @@ export async function generateObjectSafe<T>(
         model,
         schema,
         prompt: enhancedPrompt,
-        temperature
+        temperature,
+        // With structured outputs disabled, force plain JSON mode. The default
+        // ("auto" → tool mode) breaks providers that reject forced tool_choice
+        // (e.g. DeepSeek thinking models return 400
+        // "Thinking mode does not support this tool_choice").
+        ...(config.provider === "openai" && config.disableStructuredOutputs
+          ? { mode: "json" as const }
+          : {})
       }, config, "generateObjectSafe", io);
 
       return result.object;
@@ -1238,7 +1255,7 @@ export async function llmWithFallback<T>(
         return result.object;
       }
 
-      const llmModel = getModel({ provider, model, apiKey, baseUrl: config.baseUrl, ollamaBaseUrl: config.ollamaBaseUrl });
+      const llmModel = getModel({ provider, model, apiKey, baseUrl: config.baseUrl, ollamaBaseUrl: config.ollamaBaseUrl, disableStructuredOutputs: config.disableStructuredOutputs });
       const costConfig: Config = { ...config, provider, model, apiKey };
 
       const result = await monitoredGenerateObject<T>({
@@ -1246,6 +1263,9 @@ export async function llmWithFallback<T>(
         schema,
         prompt,
         temperature: 0.3,
+        ...(provider === "openai" && config.disableStructuredOutputs
+          ? { mode: "json" as const }
+          : {})
       }, costConfig, "llmWithFallback", io);
 
       return result.object;


### PR DESCRIPTION
## Problem

`disableStructuredOutputs: true` in config has no effect for the `openai` provider. Against OpenAI-compatible gateways whose endpoints don't support strict structured outputs (e.g. OpenRouter routing to DeepSeek's official endpoint, which supports `response_format` + `tools` but **not** `structured_outputs`), every `cm reflect` / validator call fails:

```
[LLM] Hard API error (400): Provider returned error. Not retrying.
```

With a DeepSeek thinking model (`deepseek/deepseek-v4-flash`) the raw provider error is:

```
Thinking mode does not support this tool_choice
```

## Root causes (three, compounding)

1. **The flag never reaches the provider factory.** `LLMConfig` doesn't carry `disableStructuredOutputs`, and both `getModel()` call sites (`generateObjectSafe`, `llmWithFallback`) build their config without it — the #47 escape hatch is silently dropped on the floor.
2. **Provider-level `structuredOutputs: false` is ignored.** In `@ai-sdk/openai` 1.x (1.3.24 in the lockfile), `structuredOutputs` is a **model-level** setting: `openaiProvider(modelId, { structuredOutputs: false })`. Passing it to `createOpenAI()` does nothing.
3. **Even with structured outputs correctly disabled, `generateObject` falls back to tool mode** (`defaultObjectGenerationMode: 'tool'` for non-reasoning model IDs), sending a forced `tool_choice: {type: "function", ...}` — which DeepSeek thinking models reject with the 400 above.

## Fix (single file, `src/llm.ts`)

- Add `disableStructuredOutputs?: boolean` to `LLMConfig`; thread it through both `getModel()` call sites.
- In the `openai` branch of `getModel()`, apply it as a model-level setting: `openaiProvider(config.model, config.disableStructuredOutputs ? { structuredOutputs: false } : {})`.
- When `provider === "openai" && disableStructuredOutputs`, pass `mode: "json"` to `generateObject` — this sends `response_format: {"type": "json_object"}` with no tools; the AI SDK injects the schema into the prompt and still validates the result with Zod post-hoc.

## Verification

- `bun run typecheck` clean; `bun run build` clean.
- Live end-to-end against OpenRouter → `deepseek/deepseek-v4-flash` (official DeepSeek endpoint): request-level probe confirms `json_schema` → 404 on that endpoint while `json_object` succeeds; with this patch `cm reflect` processes real sessions end-to-end (13 deltas from 2 sessions on first run) and `cm doctor` reports the LLM provider ready.
- Default OpenAI path is unchanged: without `disableStructuredOutputs`, behavior is identical (empty model settings object, no `mode` override).

Config used:

```json
{
  "provider": "openai",
  "model": "deepseek/deepseek-v4-flash",
  "baseUrl": "https://openrouter.ai/api/v1",
  "disableStructuredOutputs": true
}
```
